### PR TITLE
Fix pgadmin bugTrackerUrl and projectSourceUrl

### DIFF
--- a/pgadmin4/pgadmin4.nuspec
+++ b/pgadmin4/pgadmin4.nuspec
@@ -17,8 +17,8 @@ pgAdmin is designed to answer the needs of all users, from writing simple SQL qu
     <summary>pgAdmin</summary>
     <releaseNotes />
     <mailingListUrl>https://www.pgadmin.org/support/list/</mailingListUrl>
-    <bugTrackerUrl>https://redmine.postgresql.org/projects/pgadmin4</bugTrackerUrl>
-    <projectSourceUrl>https://git.postgresql.org/gitweb/?p=pgadmin4.git</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/pgadmin-org/pgadmin4/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/pgadmin-org/pgadmin4</projectSourceUrl>
     <packageSourceUrl>https://github.com/coldacid/chocolatey-packages/</packageSourceUrl>
     <copyright>1996-2018 The PostgreSQL Global Development Group</copyright>
     <tags>pgadmin4 pgadmin postgres postgresql admin</tags>


### PR DESCRIPTION
Updated the bugTrackerUrl and projectSourceUrl to reflect their new locations on github.  The invalid projectSourceUrl is currently preventing the pgAdmin chocolatey package from being approved.