### PR TITLE
Always install pgadmin4 in all-users mode (fixes #1)

### DIFF
--- a/pgadmin4/tools/chocolateyInstall.ps1
+++ b/pgadmin4/tools/chocolateyInstall.ps1
@@ -11,7 +11,7 @@ $packageArgs = @{
   unzipLocation = $toolsDir
   fileType      = 'EXE'
 
-  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' # Inno Setup
+  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS /SP-' # Inno Setup
   validExitCodes= @(0)
 
   softwareName  = 'pgAdmin 4'


### PR DESCRIPTION
Otherwise the package may be installed in current-user-mode (in `c:\Users\Administrator\AppData\Local\Programs\pgAdmin 4\v6\`), which is quite useless for most users.