### PR TITLE
pgadmin4: Update to 7.7

### DIFF
--- a/pgadmin4/tools/chocolateyInstall.ps1
+++ b/pgadmin4/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName   = 'pgadmin4'
 $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64         = 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v6.8/windows/pgadmin4-6.8-x64.exe'
-$checksum64    = 'ed90762ea7a3bec7e014c73d21dc5e1f76ce05f802a26197905fd4109696d3a8'
+$url64         = 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v7.7/windows/pgadmin4-7.7-x64.exe'
+$checksum64    = '11119290d41b879b051922da73d09460a144196a94c847053e09bc38398c685b'
 $checksumType64= 'sha256'
 
 $packageArgs = @{
@@ -11,7 +11,7 @@ $packageArgs = @{
   unzipLocation = $toolsDir
   fileType      = 'EXE'
 
-  silentArgs   = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS /SP-' # Inno Setup
+  silentArgs   = '/SILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS /SP-' # Inno Setup
   validExitCodes= @(0)
 
   softwareName  = 'pgAdmin 4'

--- a/pgadmin4/update.ps1
+++ b/pgadmin4/update.ps1
@@ -15,15 +15,16 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-  $regex   = '(?:/pgadmin/pgadmin4/v)(\d+(\.\d+)+)(?:/windows)'
-  $url     = $download_page.links | Where-Object href -Match $regex | Select-Object -First 1 -Expand href
-  $version = $url -replace ".*v(\d+(\.\d+)*).*",'$1'
+  $download_page        = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $regex                = '(?:/pgadmin/pgadmin4/v)(\d+(\.\d+)+)(?:/windows)'
+  $url                  = $download_page.links | Where-Object href -Match $regex | Select-Object -First 1 -Expand href
+  $version              = $url -replace ".*v(\d+(\.\d+)*).*",'$1'
+  $releaseNotesVersion  = $version.replace(".", "_")
 
   Write-Host $url $version
 
   $url64 = "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v${version}/windows/pgadmin4-${version}-x64.exe"
-  $releaseNotesUrl = "https://www.pgadmin.org/docs/pgadmin4/${version}/release_notes_${version}.html"
+  $releaseNotesUrl = "https://www.pgadmin.org/docs/pgadmin4/${version}/release_notes_${releaseNotesVersion}.html"
 
   return @{
     Version = $version


### PR DESCRIPTION
I tested `pgadmin4-7.7-x64.exe /SILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS /SP-` in a Windows Sandbox and it successfully installed pgAdmin. For this, I had to change the installer argument from `VERYSILENT` to `SILENT` as it didn't work otherwise.
Please let me know if you do further testing, e. g. with Chocolatey itself.